### PR TITLE
Relay task and d-graph-update msgs to SCHEDULE-MONITOR group 

### DIFF
--- a/include/ropod_com_mediator/com_mediator.h
+++ b/include/ropod_com_mediator/com_mediator.h
@@ -69,6 +69,8 @@ private:
     void parseAndPublishExperimentMessage(const Json::Value &root);
     void parseAndPublishCommandMessage(const Json::Value &root);
 
+    void sendRobotPoseMsg();
+
     void processTaskMessage(const Json::Value &root, std::string ZyreGroupName);
     void processDGraphUpdateMessage(const Json::Value &root, std::string ZyreGroupName);
 

--- a/include/ropod_com_mediator/com_mediator.h
+++ b/include/ropod_com_mediator/com_mediator.h
@@ -61,13 +61,16 @@ private:
     Json::CharReaderBuilder json_builder;
 
     std::string robotName;
-    std::string zyreGroupName;
+    std::vector<std::string> zyreGroupName;
     std::string robotSubAreaName;
 
     void parseAndPublishTaskMessage(const Json::Value &root);
     void parseAndPublishElevatorReply(const Json::Value &root);
     void parseAndPublishExperimentMessage(const Json::Value &root);
     void parseAndPublishCommandMessage(const Json::Value &root);
+
+    void processTaskMessage(const Json::Value &root, std::string ZyreGroupName);
+    void processDGraphUpdateMessage(const Json::Value &root, std::string ZyreGroupName);
 
 public:
     ComMediator(int argc, char**argv);

--- a/launch/com_mediator.launch
+++ b/launch/com_mediator.launch
@@ -1,12 +1,13 @@
 <?xml version="1.0"?>
 <launch>
     <arg name="debug_mode" default="false"/>
+    <arg name="zyreGroupName" default="[ROPOD, TASK-ALLOCATION, SCHEDULE-MONITOR]"/>
     <node name="ropod_com_mediator" pkg="ropod_com_mediator" type="ropod_com_mediator" output="screen" args="ropod_com_mediator debug_mode=$(arg debug_mode)">
         <param name="tfFrameId" type="str" value="ropod/base_link"/>
         <param name="tfFrameReferenceId" type="str" value="map"/>
         <!-- robotName param is only used if env var ROPOD_ID is not set -->
         <param name="robotName" type="str" value="ropod_001"/>
-        <param name="zyreGroupName" type="str" value="ROPOD"/>
+        <rosparam param="zyreGroupName" subst_value="True">$(arg zyreGroupName)</rosparam>
         <param name="minSendDurationInSec" type="double" value="0.1"/>
         <remap from="~robot_pose" to="/ropod/pose"/>
 	    <remap from="~robot_subarea" to="/ropod/subarea" />

--- a/src/com_mediator.cpp
+++ b/src/com_mediator.cpp
@@ -276,6 +276,8 @@ void ComMediator::progressGOTOCallback(const ropod_ros_msgs::TaskProgressGOTO::C
     msg["payload"]["taskProgress"]["actionStatus"]["status"] = ros_msg->status.status_code;
     msg["payload"]["taskProgress"]["area"] = ros_msg->area_name;
 
+    ROS_INFO("Sending task-progress msg to ROPOD group");
+
     std::stringstream feedbackMsg("");
     feedbackMsg << msg;
     this->shout(feedbackMsg.str(), "ROPOD");


### PR DESCRIPTION
- The messages `task` and `d-graph-update` are received in the  zyre group `TASK-ALLOCATION` and sent to the zyre group `SCHEDULE-MONITOR`

- The `task` messages received in the zyre group `ROPOD` are traslated to ROS task msgs and published.


![com_fms_robot_2](https://user-images.githubusercontent.com/31595992/90111362-d6d9b180-dd4e-11ea-9e25-17d32697d73f.png)
